### PR TITLE
Unuse deprecated constructors

### DIFF
--- a/src/main/java/org/embulk/filter/copy/CopyFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/copy/CopyFilterPlugin.java
@@ -104,7 +104,6 @@ public class CopyFilterPlugin
     {
         final PluginTask task = taskSource.loadTask(PluginTask.class);
         TimestampFormatter timestampFormatter = new TimestampFormatter(
-                task.getJRuby(),
                 task.getDefaultTimestampFormat(),
                 task.getDefaultTimeZone());
 

--- a/src/main/java/org/embulk/filter/copy/plugin/InternalForwardInputPlugin.java
+++ b/src/main/java/org/embulk/filter/copy/plugin/InternalForwardInputPlugin.java
@@ -75,7 +75,6 @@ public class InternalForwardInputPlugin
 
         try (PageBuilder pageBuilder = new PageBuilder(task.getBufferAllocator(), schema, output)) {
             TimestampParser timestampParser = new TimestampParser(
-                    task.getJRuby(),
                     task.getDefaultTimestampFormat(),
                     task.getDefaultTimeZone());
             InForwardEventReader eventReader = new InForwardEventReader(schema, timestampParser);


### PR DESCRIPTION
From embulk v0.8.29, Timstamp(Formatter|Parser) with JRuby becomes deprecated. So, unuse the deprecated constructors.

```
[WARN] Plugin uses deprecated constructor of org.embulk.spi.time.TimestampFormatter.
[WARN] Report plugins in your config at: https://github.com/embulk/embulk/issues/745
[WARN] Plugin uses deprecated constructor of org.embulk.spi.time.TimestampParser.
[WARN] Report plugins in your config at: https://github.com/embulk/embulk/issues/745
```
