### PR TITLE
Ship v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+0.2.0 (2020-05-07)
+==================
+- [Enhancement] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Use the `embulk-plugins` gradle plugin.
+- [Enhancement] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Re-write as a scala project.
+- [Enhancement] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Deploy the gem to rubygems.org automatically.
+- [Enhancement] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Support multiple copies
+- [Breaking Change] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Remove [the Fluentd forward protocol](https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1) dependencies.
+  - Remove the public internal configuration for the network.
+
 0.1.0 (2019-09-26)
 ==================
 * Follow embulk v0.9.x interfaces.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "pro.civitaspo"
-version = "0.1.0"
+version = "0.2.0"
 description = "An filter plugin for Embulk (https://github.com/embulk/embulk/) that" +
     " copies loaded data to your defined embulk filters & output plugins."
 


### PR DESCRIPTION
0.2.0 (2020-05-07)
==================
- [Enhancement] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Use the `embulk-plugins` gradle plugin.
- [Enhancement] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Re-write as a scala project.
- [Enhancement] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Deploy the gem to rubygems.org automatically.
- [Enhancement] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Support multiple copies
- [Breaking Change] [#15](https://github.com/civitaspo/embulk-filter-copy/pull/15) Remove [the Fluentd forward protocol](https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1) dependencies.
  - Remove the public internal configuration for the network.